### PR TITLE
“Source” menu link positioned outside the viewport

### DIFF
--- a/files/assets/css/custom.css
+++ b/files/assets/css/custom.css
@@ -28,3 +28,10 @@ blockquote p, blockquote, p {
 }
 
 .previous a,.next a{border-radius:4px}
+
+/* Workaround for bootstrap bug */
+@media (min-width: 768px) {
+  .navbar-nav.navbar-right:last-child {
+    margin-right: 0px !important;
+  }
+}


### PR DESCRIPTION
Workaround for a bug in bootstrap itself. (Or how bootstrap is being used.)
