### PR TITLE
Update getting-started.html

### DIFF
--- a/stories/getting-started.html
+++ b/stories/getting-started.html
@@ -54,7 +54,7 @@
                 </div>
                 <div id="collapseMac" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingMac">
                     <div class="panel-body">
-                        <p>Installing Nikola on OS X is easy. You can use Homebrew, MacPorts, Fink, or perform a standalone installation using the system Python.</p>
+                        <p>Installing Nikola on OS X is easy. You can use Homebrew, MacPorts, Fink, or perform a standalone installation using the system Python. For future proof installations that do support all features using Python 3.3+ over OS X's system Python is recommended.</p>
                         <h5>With <a href="http://brew.sh/">Homebrew</a> (recommended)</h5>
                         <ol>
                             <li>Install <a href="http://brew.sh/">Homebrew</a>.</li>
@@ -66,6 +66,7 @@
                         <h5>With <a href="https://www.macports.org/">MacPorts</a></h5>
                         <ol>
                             <li>Install <a href="https://www.macports.org/">MacPorts</a>.</li>
+                            <li>Update MacPorts package descriptions <code class="gs-code gs-command">sudo port selfupdate</code></li>.
                             <li>Install pip (and Python) with <code class="gs-code gs-command">sudo port install py35-pip</code> (or a newer Python version, if available — please check the repos)</li>
                             <li>Install virtualenv with <code class="gs-code gs-command">sudo port install py35-virtualenv</code></li>
                             <li>Follow the instructions <span class="hidden-xs hidden-sm hidden-print">on the right</span><span class="hidden">/</span><span class="visible-xs-inline visible-sm-inline">below</span>.</li>
@@ -73,6 +74,7 @@
                         <h5>With <a href="http://www.finkproject.org/">Fink</a></h5>
                         <ol>
                             <li>Install <a href="http://www.finkproject.org/">Fink</a>.</li>
+                            <li>Update fink package descriptions <code class="gs-code gs-command">fink selfupdate</code>.</li>
                             <li>Install pip, virtualenv and Python with <code class="gs-code gs-command">sudo fink install pip-py35 virtualenv-py35</code> (or a newer Python version, if available — please check the repos)</li>
                             <li>Follow the instructions <span class="hidden-xs hidden-sm hidden-print">on the right</span><span class="hidden">/</span><span class="visible-xs-inline visible-sm-inline">below</span>.</li>
                         </ol>


### PR DESCRIPTION
Added step to always update MacPorts and Fink package descriptions so people actually get the most up-to-date versions available.
Added a sentence to encourage using Python 3.3+ over OS X's neglected system Python (which also requires admin privs to use easy-install and pip).