### PR TITLE
Change reference to doc role

### DIFF
--- a/stories/manual.txt
+++ b/stories/manual.txt
@@ -1029,7 +1029,7 @@ Built-in shortcodes
 ~~~~~~~~~~~~~~~~~~~
 
 doc
-    Will link to a document in the page, see `Doc directive for details
+    Will link to a document in the page, see `Doc role for details
     <#doc>`__. Example:
 
     .. code:: restructuredtext


### PR DESCRIPTION
Minor change, but since the doc role is (correctly) referenced as a role in one place, but as a directive in the other, I changed it to be role for uniformity.